### PR TITLE
feat: let integrations narrow the PE transfer-method options

### DIFF
--- a/payment_integration_utils/payment_integration_utils/client_overrides/form/payment_entry.js
+++ b/payment_integration_utils/payment_integration_utils/client_overrides/form/payment_entry.js
@@ -26,9 +26,7 @@ const PAYMENT_FIELDS = [
     "reference_no",
 ];
 
-// Narrow the transfer-method Select to the options the claiming integration
-// supports (onload: payment_transfer_method_options); leaves the full default
-// set when none is provided. On a draft, resets a now-invalid value to the first.
+// narrow transfer-method options to integration's supported set
 function apply_transfer_method_options(frm) {
     const options = payment_integration_utils.get_onload(frm, "payment_transfer_method_options");
     if (!options || !options.length) return;
@@ -60,7 +58,6 @@ frappe.ui.form.on("Payment Entry", {
         // user can make payment `on submit`
         update_submit_button_label(frm);
 
-        // narrow transfer-method options to what the claiming integration supports
         apply_transfer_method_options(frm);
     },
 

--- a/payment_integration_utils/payment_integration_utils/client_overrides/form/payment_entry.js
+++ b/payment_integration_utils/payment_integration_utils/client_overrides/form/payment_entry.js
@@ -30,7 +30,7 @@ const PAYMENT_FIELDS = [
 function apply_transfer_method_options(frm) {
     const options = payment_integration_utils.get_onload(frm, "payment_transfer_method_options");
     if (!options || !options.length) return;
-    frm.set_df_property("payment_transfer_method", "options", options.join("\n"));
+    frm.set_df_property("payment_transfer_method", "options", options);
     if (
         frm.doc.docstatus === 0 &&
         frm.doc.payment_transfer_method &&

--- a/payment_integration_utils/payment_integration_utils/client_overrides/form/payment_entry.js
+++ b/payment_integration_utils/payment_integration_utils/client_overrides/form/payment_entry.js
@@ -26,6 +26,22 @@ const PAYMENT_FIELDS = [
     "reference_no",
 ];
 
+// Narrow the transfer-method Select to the options the claiming integration
+// supports (onload: payment_transfer_method_options); leaves the full default
+// set when none is provided. On a draft, resets a now-invalid value to the first.
+function apply_transfer_method_options(frm) {
+    const options = payment_integration_utils.get_onload(frm, "payment_transfer_method_options");
+    if (!options || !options.length) return;
+    frm.set_df_property("payment_transfer_method", "options", options.join("\n"));
+    if (
+        frm.doc.docstatus === 0 &&
+        frm.doc.payment_transfer_method &&
+        !options.includes(frm.doc.payment_transfer_method)
+    ) {
+        frm.set_value("payment_transfer_method", options[0]);
+    }
+}
+
 frappe.ui.form.on("Payment Entry", {
     refresh: async function (frm) {
         // Do not allow to edit fields if Payment is processed by RazorpayX in amendment
@@ -43,6 +59,9 @@ frappe.ui.form.on("Payment Entry", {
 
         // user can make payment `on submit`
         update_submit_button_label(frm);
+
+        // narrow transfer-method options to what the claiming integration supports
+        apply_transfer_method_options(frm);
     },
 
     validate: function (frm) {

--- a/payment_integration_utils/payment_integration_utils/server_overrides/doctype/payment_entry.py
+++ b/payment_integration_utils/payment_integration_utils/server_overrides/doctype/payment_entry.py
@@ -33,6 +33,25 @@ def onload(doc: PaymentEntry, method=None):
         has_payment_permissions(doc.name, throw=False, ignore_impersonation=True),
     )
 
+    doc.set_onload("payment_transfer_method_options", _transfer_method_options(doc))
+
+
+def _transfer_method_options(doc: PaymentEntry) -> list[str] | None:
+    """First ``payment_transfer_method_options`` hook returning a non-empty list
+    narrows the PE's transfer-method choices to what the claiming integration
+    supports (e.g. a bank with no UPI/Link). ``None`` -> the full default set, so
+    an integration that registers nothing (or none installed) is unaffected. A
+    resolver error degrades to the full set rather than breaking the form."""
+    for path in frappe.get_hooks("payment_transfer_method_options"):
+        try:
+            methods = frappe.get_attr(path)(doc)
+        except Exception:
+            frappe.log_error(title="payment_transfer_method_options resolver failed")
+            continue
+        if methods:
+            return list(methods)
+    return None
+
 
 def validate(doc: PaymentEntry, method=None):
     validate_if_already_paid(doc)

--- a/payment_integration_utils/payment_integration_utils/server_overrides/doctype/payment_entry.py
+++ b/payment_integration_utils/payment_integration_utils/server_overrides/doctype/payment_entry.py
@@ -41,11 +41,11 @@ def _transfer_method_options(doc: PaymentEntry) -> list[str] | None:
     for path in frappe.get_hooks("payment_transfer_method_options"):
         try:
             methods = frappe.get_attr(path)(doc)
+            if methods:
+                return list(methods)
         except Exception:
             frappe.log_error(title="payment_transfer_method_options resolver failed")
             continue
-        if methods:
-            return list(methods)
     return None
 
 

--- a/payment_integration_utils/payment_integration_utils/server_overrides/doctype/payment_entry.py
+++ b/payment_integration_utils/payment_integration_utils/server_overrides/doctype/payment_entry.py
@@ -37,11 +37,7 @@ def onload(doc: PaymentEntry, method=None):
 
 
 def _transfer_method_options(doc: PaymentEntry) -> list[str] | None:
-    """First ``payment_transfer_method_options`` hook returning a non-empty list
-    narrows the PE's transfer-method choices to what the claiming integration
-    supports (e.g. a bank with no UPI/Link). ``None`` -> the full default set, so
-    an integration that registers nothing (or none installed) is unaffected. A
-    resolver error degrades to the full set rather than breaking the form."""
+    # first hook with a non-empty list wins; None means use default options
     for path in frappe.get_hooks("payment_transfer_method_options"):
         try:
             methods = frappe.get_attr(path)(doc)


### PR DESCRIPTION
Add a `payment_transfer_method_options` hook: onload resolves the first registered resolver's non-empty list of allowed methods for the PE, and the PE client JS narrows the Select to it (resetting a now-invalid draft value to the first). No resolver / none installed -> the full default set, so razorpayx is unaffected; a resolver error degrades to the full set rather than breaking the form. Lets a bank integration hide UPI/Link its banks don't support without a global, install-order-dependent property setter.